### PR TITLE
Add the management integrations squad as collaborators

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,9 +3,17 @@ approvers:
 - dhaiducek
 - KevinFCormier
 - itdove
+- TheRealHaoLiu
+- hanqiuzh
+- CrystalChun
+- taragu
 
 reviewers:
 - gurnben
 - dhaiducek
 - KevinFCormier
 - itdove
+- TheRealHaoLiu
+- hanqiuzh
+- CrystalChun
+- taragu


### PR DESCRIPTION
## Summary of Changes

The management integration squad is coming online to drive development work into the ocmplus.cm Ansible collection.  They're going to join the working group and develop this collection as their day job (woo!!!).  