### PR TITLE
Refactor for role ocm-install-observability for inventory

### DIFF
--- a/roles/ocm-install-observability/README.md
+++ b/roles/ocm-install-observability/README.md
@@ -14,31 +14,12 @@ Object storage is required to store the metrics. This store needs to be accessib
 Disconnected installs are possible provided that the images are mirrored internally.
 
 
-Environment Variables
----------------------
-
-Environment variables provide the credentials needed by the kubernetes.core collection to connect to the cluster.
-
-* Option 1, use kubeconfig. Preferred.
-* Option 2, use access token.
-* Option 3, use username/password. 
-
-| Variable                | Required           | Default                            | Comments                                 |
-|-------------------------|--------------------|------------------------------------|------------------------------------------|
-| K8S_AUTH_KUBECONFIG     | yes, Option 1      | ~/.kube/kubeconfig                 | Path to Kubeconfig                       |
-| K8S_AUTH_HOST           | yes, Option 2,3    | https://api.cluster.domain.com     | URL to the cluster API                   |
-| K8S_AUTH_VERIFY_SSL     | yes, Option 2,3    |                                    | Flag to enforce SSL verification         |
-| K8S_AUTH_SSL_CA_CERT    | yes, Option 2,3    |                                    | Path to Certificate Authority            |
-| K8S_AUTH_API_KEY        | yes, Option 2      |                                    | Token for a cluster-admin                |
-| K8S_AUTH_USERNAME       | yes, Option 3      |                                    | Username for a cluster-admin             |
-| K8S_AUTH_PASSWORD       | yes, Option 3      |                                    | Password for a cluster-admin             |
-
-
 Role Variables
 --------------
 
 | Variable                | Required           | Default                            | Comments                                 |
 |-------------------------|--------------------|------------------------------------|------------------------------------------|
+| ocm_hub_kubeconfig      | yes                |                                    | Path to kubeconfig for the hub           |
 | ocm_s3_endpoint         | yes                | overrideme.us-west-1.acmecloud.com | S3 Endpoint for Observability/Thanos     |
 | ocm_s3_bucket           | yes                | overrideme                         | S3 Bucket                                |
 | ocm_s3_access_key       | yes                | overrideme                         | S3 Access Key                            |
@@ -62,18 +43,29 @@ The python modules *kubernetes* and *jmespath* are required to connect and extra
 Example Playbook
 ----------------
 
-1. Ensure that the above python modules and collections are available.
-2. Ensure the kubeconfig for the target cluster(s) are available.
-3. Then run the test.yml under the tests directory.
+An example of how to run this role with a well formed inventory.
+
+Contents of inventory:
+
+    [hub_cluster]
+    test-cluster-1 kubeconfig=/path/to/kubeconfig1
+
+    [managed_clusters]
+    test-cluster-2 kubeconfig=/path/to/kubeconfig2
+    test-cluster-3 kubeconfig=/path/to/kubeconfig3
+    test-cluster-4 kubeconfig=/path/to/kubeconfig4
+
+    [all:vars]
+    ansible_python_interpreter=/path/to/venv/bin/python
 
 tests/test.yml:
 
-    - hosts: servers
-      environment:
-        K8S_AUTH_KUBECONFIG: /path/to/kubeconfig
+    - hosts: hub_cluster
+      connection: local
       roles:
-        - role: ocm-install-observability
+        - role: ../../ocm-install-observability
           vars:
+            ocm_hub_kubeconfig: "{{ hostvars[inventory_hostname].kubeconfig }}"
             ocm_s3_endpoint: cloudstorage.acmecloud.com
             ocm_s3_bucket: bucket4metrics
             ocm_s3_access_key: ABCDE12345abcde

--- a/roles/ocm-install-observability/tasks/main.yml
+++ b/roles/ocm-install-observability/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Create Observability namespace
   kubernetes.core.k8s:
+    kubeconfig: "{{ ocm_hub_kubeconfig }}"
     state: present
     definition:
       apiVersion: v1
@@ -10,23 +11,26 @@
 
 - name: Create Thanos credentials
   kubernetes.core.k8s:
+    kubeconfig: "{{ ocm_hub_kubeconfig }}"
     state: present
     template: thanoscreds.yml
     
 - name: Extract Openshift Config Pull Secret
   set_fact:
-    ocm_pull_secret: "{{ lookup('kubernetes.core.k8s', api_version='v1', kind='Secret', namespace='openshift-config', resource_name='pull-secret') | json_query(query) }}"
+    ocm_pull_secret: "{{ lookup('kubernetes.core.k8s', kubeconfig=ocm_hub_kubeconfig, api_version='v1', kind='Secret', namespace='openshift-config', resource_name='pull-secret') | json_query(query) }}"
   vars:
     query: "data.\".dockerconfigjson\""
   no_log: true
 
 - name: Create MCO pullsecret
   kubernetes.core.k8s:
+    kubeconfig: "{{ ocm_hub_kubeconfig }}"
     state: present
     template: multiclusterobs-pullsecret.yml
     
 - name: Create MCO instance
   kubernetes.core.k8s:
+    kubeconfig: "{{ ocm_hub_kubeconfig }}"
     state: present
     template: multiclusterobs.yml
     wait: true

--- a/roles/ocm-install-observability/tests/inventory
+++ b/roles/ocm-install-observability/tests/inventory
@@ -1,2 +1,10 @@
-localhost
+[hub_cluster]
+test-cluster-1 kubeconfig=/path/to/kubeconfig1
 
+[managed_clusters]
+test-cluster-2 kubeconfig=/path/to/kubeconfig2
+test-cluster-3 kubeconfig=/path/to/kubeconfig3
+test-cluster-4 kubeconfig=/path/to/kubeconfig4
+
+[all:vars]
+ansible_python_interpreter=/path/to/venv/bin/python

--- a/roles/ocm-install-observability/tests/test.yml
+++ b/roles/ocm-install-observability/tests/test.yml
@@ -1,12 +1,11 @@
 ---
-- hosts: localhost
-  remote_user: root
-  environment:
-    K8S_AUTH_KUBECONFIG: ~/.kube/kubeconfig
+- hosts: hub_cluster
+  connection: local
   roles:
-    - ../../ocm-install-observability
-  vars:
-    ocm_s3_endpoint: cloudstorage.acmecloud.com
-    ocm_s3_bucket: bucket4metrics
-    ocm_s3_access_key: ABCDE12345abcde
-    ocm_s3_secret_key: abcde12345fghij67890
+    - role: ../../ocm-install-observability
+      vars:
+        ocm_hub_kubeconfig: "{{ hostvars[inventory_hostname].kubeconfig }}"
+        ocm_s3_endpoint: cloudstorage.acmecloud.com
+        ocm_s3_bucket: bucket4metrics
+        ocm_s3_access_key: ABCDE12345abcde
+        ocm_s3_secret_key: abcde12345fghij67890


### PR DESCRIPTION
/cc @gurnben @TheRealHaoLiu 

For consistency, all roles are being refactored to take into account a standardized inventory. This allows the roles to handle multicluster actions and drives requirements for the dynamic inventory plugin.