### PR TITLE
Add upgrade logic

### DIFF
--- a/roles/ocm-install-core/README.md
+++ b/roles/ocm-install-core/README.md
@@ -3,6 +3,8 @@ ocm-install-core
 
 Installs Red Hat Advanced Cluster Management Operator with the MultiClusterHub (MCH).
 
+If a previous instance of the Operator exists, upgrade logic will be employed to bring the cluster to the desired version.
+
 
 Requirements
 ------------
@@ -22,7 +24,7 @@ Role Variables
 | ocm_install_catalog_ns  | no                 | openshift-marketplace              | Namespace of the catalog                 |
 | ocm_version             | no                 | 2.3.3                              | Desired RHACM version                    |
 | ocm_channel             | no                 | release-2.3                        | Channel of the desired RHACM version     |
-
+| ocm_lockversion         | no                 | false                              | Operator Plan Approval (false=Automatic) |
 
 Dependencies
 ------------

--- a/roles/ocm-install-core/defaults/main.yml
+++ b/roles/ocm-install-core/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ocm_install_catalog: redhat-operators
 ocm_install_catalog_ns: openshift-marketplace
-ocm_version: 2.3.3
 ocm_channel: release-2.3
-
+ocm_version: 2.3.3
+ocm_lockversion: false

--- a/roles/ocm-install-core/tasks/main.yml
+++ b/roles/ocm-install-core/tasks/main.yml
@@ -22,7 +22,42 @@
       spec:
         targetNamespaces:
           - open-cluster-management
-          
+
+- name: Operator Subscription Exists
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: advanced-cluster-management
+    namespace: open-cluster-management
+  register: ocm_operator_sub
+
+- name: Assumed Installing
+  set_fact:
+    upgrading: false
+
+- name: Subscription Exists, but Test if New Version
+  block:
+    - name: Get Currently Installed Subscription
+      set_fact:
+        ocm_installedCSV: "{{ lookup('k8s', kubeconfig=ocm_hub_kubeconfig, api_version='operators.coreos.com/v1alpha1', kind='Subscription', namespace='open-cluster-management', resource_name='advanced-cluster-management') | json_query(query) }}"
+      vars:
+        query: "status.installedCSV"
+
+    - name: Is New Version
+      set_fact:
+        upgrading: "{{ ocm_installedCSV != 'advanced-cluster-management.v' + ocm_version }}"
+  when: ocm_operator_sub.resources | length != 0
+
+- name: "[Install] Set ocm_startingCSV"
+  set_fact:
+    ocm_startingCSV: "advanced-cluster-management.v{{ ocm_version }}"
+  when: not upgrading
+
+- name: "[Upgrade] Set ocm_startingCSV"
+  set_fact:
+    ocm_startingCSV: "advanced-cluster-management.v{{ ocm_installedCSV }}"
+  when: upgrading
+
 - name: Create Operator Subscription
   kubernetes.core.k8s:
     kubeconfig: "{{ ocm_hub_kubeconfig }}"
@@ -34,26 +69,46 @@
       reason: 'AllCatalogSourcesHealthy'
       status: 'False'
 
-- name: Wait for MultiClusterHub (MCH) CRD
-  kubernetes.core.k8s_info:
-    kubeconfig: "{{ ocm_hub_kubeconfig }}"
-    kind: CustomResourceDefinition
-    name: multiclusterhubs.operator.open-cluster-management.io
-    wait: true
-    wait_condition:
-      type: 'Established'
-      reason: 'InitialNamesAccepted'
-      status: 'True'
-    wait_timeout: 300
+- name: Confirm Install of MultiClusterHub
+  block:
+    - name: "[Install] Wait for MultiClusterHub (MCH) CRD"
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ ocm_hub_kubeconfig }}"
+        kind: CustomResourceDefinition
+        name: multiclusterhubs.operator.open-cluster-management.io
+        wait: true
+        wait_condition:
+          type: 'Established'
+          reason: 'InitialNamesAccepted'
+          status: 'True'
+        wait_timeout: 300
 
-- name: Setup MultiClusterHub (MCH) instance
-  kubernetes.core.k8s:
-    state: present
-    kubeconfig: "{{ ocm_hub_kubeconfig }}"
-    template: multiclusterhub.yml
-    wait: true
-    wait_condition:
-      type: 'Complete'
-      reason: 'ComponentsAvailable'
-      status: 'True'
-    wait_timeout: 600
+    - name: "[Install] Setup MultiClusterHub (MCH) instance"
+      kubernetes.core.k8s:
+        state: present
+        kubeconfig: "{{ ocm_hub_kubeconfig }}"
+        template: multiclusterhub.yml
+        wait: true
+        wait_condition:
+          type: 'Complete'
+          reason: 'ComponentsAvailable'
+          status: 'True'
+        wait_timeout: 600
+  when: not upgrading
+
+- name: Confirm Upgrade of MultiClusterHub
+  block:
+    - name: "[Upgrade] Wait for MultiClusterHub (MCH) instance"
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ ocm_hub_kubeconfig }}"
+        api_version: operator.open-cluster-management.io/v1
+        kind: MultiClusterHub
+        name: multiclusterhub
+        namespace: open-cluster-management
+        wait: true
+        wait_condition:
+          type: 'Complete'
+          reason: 'ComponentsAvailable'
+          status: 'True'
+        wait_timeout: 600
+  when: upgrading

--- a/roles/ocm-install-core/tasks/main.yml
+++ b/roles/ocm-install-core/tasks/main.yml
@@ -58,6 +58,10 @@
     ocm_startingCSV: "advanced-cluster-management.v{{ ocm_installedCSV }}"
   when: upgrading
 
+- name: Plan Approval Automatic for Install/Upgrade
+  set_fact:
+    ocm_plan_approval: 'Automatic'
+
 - name: Create Operator Subscription
   kubernetes.core.k8s:
     kubeconfig: "{{ ocm_hub_kubeconfig }}"
@@ -98,6 +102,18 @@
 
 - name: Confirm Upgrade of MultiClusterHub
   block:
+    - name: "[Upgrade] Wait until old OCM Operator Removed"
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ ocm_hub_kubeconfig }}"
+        api_version: operators.coreos.com/v1alpha1
+        kind: ClusterServiceVersion
+        name: "{{ ocm_installedCSV }}"
+        namespace: open-cluster-management
+      register: ocm_old_operator
+      until: ocm_old_operator.resources | length == 0
+      retries: 15
+      delay: 20
+
     - name: "[Upgrade] Wait for MultiClusterHub (MCH) instance"
       kubernetes.core.k8s_info:
         kubeconfig: "{{ ocm_hub_kubeconfig }}"
@@ -112,3 +128,13 @@
           status: 'True'
         wait_timeout: 600
   when: upgrading
+
+- name: "Set Plan Approval"
+  set_fact:
+    ocm_plan_approval: "{{ ocm_lockversion | ternary('Manual', 'Automatic', 'Manual') }}"
+
+- name: "Update Operator Subscription with Plan Approval"
+  kubernetes.core.k8s:
+    kubeconfig: "{{ ocm_hub_kubeconfig }}"
+    state: present
+    template: operator.yml

--- a/roles/ocm-install-core/templates/operator.yml
+++ b/roles/ocm-install-core/templates/operator.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   source: {{ ocm_install_catalog }}
   sourceNamespace: {{ ocm_install_catalog_ns }}
-  installPlanApproval: Automatic
+  installPlanApproval: {{ ocm_plan_approval }}
   name: advanced-cluster-management
   startingCSV: {{ ocm_startingCSV }}
   channel: {{ ocm_channel }}

--- a/roles/ocm-install-core/templates/operator.yml
+++ b/roles/ocm-install-core/templates/operator.yml
@@ -7,8 +7,8 @@ metadata:
 spec:
   source: {{ ocm_install_catalog }}
   sourceNamespace: {{ ocm_install_catalog_ns }}
-  installPlanApproval: "Automatic"
+  installPlanApproval: Automatic
   name: advanced-cluster-management
-  startingCSV: advanced-cluster-management.v{{ ocm_version }}
+  startingCSV: {{ ocm_startingCSV }}
   channel: {{ ocm_channel }}
 ...


### PR DESCRIPTION
Extended the ocm-install-core role to handle situations where there already exists an older version of the operator. The new code will handle the upgrade.

Also added additional variable for setting the Plan Approval (Automatic vs Manual).

/cc @TheRealHaoLiu @gurnben 