### PR TITLE
Add managedcluster_info module

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Name | Description
 [stolostron.core.managedcluster_addon](https://github.com/stolostron/ansible-collection.core/blob/main/docs/managedcluster_addon_module.rst)| Use managedcluster_addon to enable/disable an addon on a managedcluster.
 [stolostron.core.ocm_managedcluster](https://github.com/stolostron/ansible-collection.core/blob/main/docs/ocm_managedcluster_inventory.rst)| Fetch ocm managedclusters, and group clusters by labels. Hub cluster information will be stored in the "hub" group.
 [stolostron.core.cluster_management_addon](https://github.com/stolostron/ansible-collection.core/blob/main/docs/cluster_management_addon_module.rst)| Use cluster_management_addon to enable/disable a feature on the hub. Users can only install an addon on managed clusters if the feature of that addon is enabled. This plugin will need access to the Multicloudhub CR, and it enables/disables available features by updating the corresponding fields in the CR.
+[stolostron.core.managedcluster_info](https://github.com/stolostron/ansible-collection.core/blob/main/docs/managedcluster_info_module.rst)| Use managedcluster_info to retrieve information about one or more managed clusters from the hub.
 <!--end collection content-->
 
 ## Installation and Usage

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ Modules
 * :ref:`managed_serviceaccount <ansible_collections.stolostron.core.managed_serviceaccount_module>` -- managed serviceaccount
 * :ref:`managed_serviceaccount_rbac <ansible_collections.stolostron.core.managed_serviceaccount_rbac_module>` -- managed-serviceaccount RBAC
 * :ref:`managedcluster_addon <ansible_collections.stolostron.core.managedcluster_addon_module>` -- managed cluster addon
+* :ref:`managedcluster_info <ansible_collections.stolostron.core.managedcluster_info_module>` -- Retrieve information about one or more managed clusters from the hub
 
 
 .. seealso::

--- a/docs/managedcluster_info_module.rst
+++ b/docs/managedcluster_info_module.rst
@@ -1,0 +1,254 @@
+.. Document meta
+
+:orphan:
+
+.. Anchors
+
+.. _ansible_collections.stolostron.core.managedcluster_info_module:
+
+.. Anchors: short name for ansible.builtin
+
+.. Anchors: aliases
+
+
+
+.. Title
+
+stolostron.core.managedcluster_info -- Retrieve information about one or more managed clusters from the hub
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. Collection note
+
+.. note::
+    This plugin is part of the `stolostron.core collection <https://galaxy.ansible.com/stolostron/core>`_ (version 0.0.2).
+
+    To install it use: :code:`ansible-galaxy collection install stolostron.core`.
+
+    To use it in a playbook, specify: :code:`stolostron.core.managedcluster_info`.
+
+.. version_added
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+.. Deprecated
+
+
+Synopsis
+--------
+
+.. Description
+
+- Retrieve information about managed clusters from the Hub.
+
+
+.. Aliases
+
+
+.. Requirements
+
+
+.. Options
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-cluster"></div>
+                    <b>cluster</b>
+                    <a class="ansibleOptionLink" href="#parameter-cluster" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                                        </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Restrict results by specific cluster.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-hub_kubeconfig"></div>
+                    <b>hub_kubeconfig</b>
+                    <a class="ansibleOptionLink" href="#parameter-hub_kubeconfig" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                                        </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Path to the Hub cluster kubeconfig. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+.. Notes
+
+
+.. Seealso
+
+
+.. Examples
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: "Retrieve information for all managed clusters"
+      stolostron.core.managedcluster_info:
+        hub_kubeconfig: /path/to/hub/kubeconfig
+
+    - name: "Retrieve information for specific managed cluster"
+      stolostron.core.managedcluster_info:
+        hub_kubeconfig: /path/to/hub/kubeconfig
+        cluster: cluster_name
+
+
+
+
+.. Facts
+
+
+.. Return values
+
+Return Values
+-------------
+Common return values are documented :ref:`here <common_return_values>`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-results"></div>
+                    <b>results</b>
+                    <a class="ansibleOptionLink" href="#return-results" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">complex</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>A dictionary of results output</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                        <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-results/claims"></div>
+                    <b>claims</b>
+                    <a class="ansibleOptionLink" href="#return-results/claims" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>The cluster claims</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-results/conditions"></div>
+                    <b>conditions</b>
+                    <a class="ansibleOptionLink" href="#return-results/conditions" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=string</span>                    </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Conditions state of the cluster</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-results/labels"></div>
+                    <b>labels</b>
+                    <a class="ansibleOptionLink" href="#return-results/labels" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Dict of cluster labels</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-results/name"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#return-results/name" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Managed cluster name</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-results/version"></div>
+                    <b>version</b>
+                    <a class="ansibleOptionLink" href="#return-results/version" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                            <div>Version of the cluster</div>
+                                        <br/>
+                                    </td>
+            </tr>
+                    
+                        </table>
+    <br/><br/>
+
+..  Status (Presently only deprecated)
+
+
+.. Authors
+
+Authors
+~~~~~~~
+
+- Maxim Babushkin (@MaxBab)
+
+
+
+.. Parsing errors
+

--- a/plugins/modules/managedcluster_info.py
+++ b/plugins/modules/managedcluster_info.py
@@ -1,0 +1,164 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+
+module: managedcluster_info
+
+short_description: Retrieve information about one or more managed clusters from the hub
+
+author:
+- "Maxim Babushkin (@MaxBab)"
+
+description:
+- Retrieve information about managed clusters from the Hub.
+
+options:
+    hub_kubeconfig:
+        description: Path to the Hub cluster kubeconfig. Can also be specified via K8S_AUTH_KUBECONFIG environment variable.
+        type: str
+        required: True
+    cluster:
+        description: Restrict results by specific cluster.
+        type: str
+        required: False
+'''
+
+EXAMPLES = r'''
+- name: "Retrieve information for all managed clusters"
+  stolostron.core.managedcluster_info:
+    hub_kubeconfig: /path/to/hub/kubeconfig
+
+- name: "Retrieve information for specific managed cluster"
+  stolostron.core.managedcluster_info:
+    hub_kubeconfig: /path/to/hub/kubeconfig
+    cluster: cluster_name
+'''
+
+RETURN = r'''
+results:
+  type: complex
+  description: A dictionary of results output
+  returned: success
+  contains:
+    name:
+      description: Managed cluster name
+      type: str
+      returned: success
+    version:
+      description: Version of the cluster
+      type: str
+      returned: success
+    labels:
+      description: Dict of cluster labels
+      type: dict
+      returned: success
+    cluster_claims:
+      description: The cluster claims
+      type: dict
+      returned: success
+    conditions:
+      description: Conditions state of the cluster
+      type: list
+      returned: success
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule, env_fallback, missing_required_lib
+
+IMP_ERR = {}
+try:
+    import kubernetes
+    from kubernetes.dynamic.exceptions import NotFoundError
+except ImportError as e:
+    IMP_ERR['k8s'] = {'error': traceback.format_exc(),
+                      'exception': e}
+
+
+def parse_labels(data):
+    label_dict = {}
+
+    for label in data:
+        label_dict[label[0]] = label[1]
+
+    return label_dict
+
+
+def parse_cluster_claims(data):
+    claim_dict = {}
+
+    for claim in data:
+        claim_dict[claim["name"]] = claim["value"]
+
+    return claim_dict
+
+
+def parse_conditions(data):
+    condition_list = []
+
+    for condition in data:
+        condition_list.append(
+            {"type": condition["type"],
+             "reason": condition["reason"],
+             "message": condition["message"],
+             "status": condition["status"]}
+        )
+
+    return condition_list
+
+
+def execute_module(module: AnsibleModule):
+    results = []
+
+    if 'k8s' in IMP_ERR:
+        # we will need k8s for this module
+        module.fail_json(msg=missing_required_lib('kubernetes'),
+                         exception=IMP_ERR['k8s']['exception'])
+
+    cluster = module.params['cluster']
+    hub_kubeconfig = kubernetes.config.load_kube_config(
+        config_file=module.params['hub_kubeconfig'])
+    hub_client = kubernetes.dynamic.DynamicClient(
+        kubernetes.client.api_client.ApiClient(configuration=hub_kubeconfig)
+    )
+
+    v1_managedclusters = hub_client.resources.get(
+        api_version="cluster.open-cluster-management.io/v1", kind="ManagedCluster")
+    cluster_selection = ""
+    if cluster:
+        cluster_selection = f"name={cluster}"
+
+    obj = v1_managedclusters.get(label_selector=cluster_selection)
+    for cl in obj.items:
+        results.append(
+            {"name": cl.metadata.name,
+             "labels": parse_labels(cl.metadata.labels),
+             "cluster_claims": parse_cluster_claims(cl.status.clusterClaims),
+             "conditions": parse_conditions(cl.status.conditions),
+             "version": cl.status.version.kubernetes}
+        )
+
+    module.exit_json(changed=False, results=results)
+
+
+def main():
+    argument_spec = dict(
+        hub_kubeconfig=dict(type='str', required=True, fallback=(
+            env_fallback, ['K8S_AUTH_KUBECONFIG'])),
+        cluster=dict(type='str', required=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    execute_module(module)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The new - managedcluster_info module will be able to retrieve managed clusters information from the Hub.
The following information will be available for each cluster:
- name
- labels
- cluster claims
- conditions
- version

The module is able to fetch specific cluster by specifying "cluster" parameter.

Signed-off-by: Maxim Babushkin <mbabushk@redhat.com>